### PR TITLE
Media Queries Level 4 deprecated `device-width`

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -565,7 +565,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -564,7 +564,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": true
             }
           }


### PR DESCRIPTION
# Summary

Media Queries Level 4 deprecated `device-width` (along with `device-height` and `device-aspect-ratio`, which are already marked as deprecated in MDN). This commit marks `device-width` as non-standard and deprecate, matching `device-height` and `device-aspect-ratio`.

# Data
See the official W3C Candidate Recommendation Media Queries Level 4:
https://www.w3.org/TR/mediaqueries-4/#mf-deprecated

# Related data
`device-height` and `device-aspect-ratio` are already marked as deprecated and not on standards track. E.g., see the JSON or the table:
https://developer.mozilla.org/en-US/docs/Web/CSS/@media#Browser_compatibility

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any