### PR TITLE
Add Manifest V3 data: Content Security Policy

### DIFF
--- a/webextensions/manifest/content_security_policy.json
+++ b/webextensions/manifest/content_security_policy.json
@@ -24,6 +24,153 @@
               "version_added": true
             }
           }
+        },
+        "content_scripts": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy#content_scripts",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "notes": "See <code>isolated_world</code>."
+              },
+              "edge": {
+                "version_added": false,
+                "notes": "See <code>isolated_world</code>."
+              },
+              "firefox": {
+                "version_added": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "extensions.content_script_csp.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "extensions.content_script_csp.report_only",
+                    "value_to_set": "false"
+                  }
+                ]
+              },
+              "firefox_android": {
+                "version_added": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "extensions.content_script_csp.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "extensions.content_script_csp.report_only",
+                    "value_to_set": "false"
+                  }
+                ]
+              },
+              "opera": {
+                "version_added": false,
+                "notes": "See <code>isolated_world</code>."
+              }
+            }
+          }
+        },
+        "extension_pages": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy#extension_pages",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "notes": "Available in Canary builds."
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "extensions.content_script_csp.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "extensions.content_script_csp.report_only",
+                    "value_to_set": "false"
+                  }
+                ]
+              },
+              "firefox_android": {
+                "version_added": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "extensions.content_script_csp.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "extensions.content_script_csp.report_only",
+                    "value_to_set": "false"
+                  }
+                ]
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "isolated_world": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy#isolated_world",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "notes": "Not yet implemented."
+              },
+              "edge": {
+                "version_added": false,
+                "notes": "Not yet implemented."
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See <code>content_scripts</code>."
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "See <code>content_scripts</code>."
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "sandbox": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy#sandbox",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "notes": "Available in Canary builds."
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "Firefox does not support sandboxed scripts, so this key is not applicable."
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "Firefox does not support sandboxed scripts, so this key is not applicable."
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

Manifest V3 is being implemented right now, data about it is already officially available.

## Data
 - Firefox: [Test the new Content Security Policy for Content Scripts](https://blog.mozilla.org/addons/2019/12/12/test-the-new-csp-for-content-scripts/)
 - Chrome:
   - [Announcement: Start experimenting with parts of MV3](https://groups.google.com/a/chromium.org/forum/#!topic/chromium-extensions/hG6ymUx7NoQ)
   - [Migrating to Manifest V3](https://developer.chrome.com/extensions/migrating_to_manifest_v3)

Also, `content_security_policy.__compat` describes the "old" Manifest V2 format, so probably it might makes sense to call it this way?

A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
