### PR TITLE
TEST

### DIFF
--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -715,6 +715,26 @@
             }
           }
         },
+        "getVersion": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "143"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1992418"
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": "26.2"
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
         "id": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/id",


### PR DESCRIPTION
Add data for the new runtime.getVersion() method, supported on Chrome 143+,[1] Safari 26.2.[2][3] Firefox does not support it yet.[4]

This method was created in W3C WECG as a standard way to access extension version, and an alternative to implementation-dependent runtime.getManifest().version.[5][6]

Sources:
[1] https://developer.chrome.com/docs/extensions/reference/api/runtime#method-getVersion [2] https://developer.apple.com/documentation/safari-release-notes/safari-26_2-release-notes [3] https://github.com/WebKit/WebKit/pull/51763
[4] https://bugzilla.mozilla.org/show_bug.cgi?id=1992418 [5] https://github.com/w3c/webextensions/issues/878 [6] https://github.com/w3c/webextensions/issues/400

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
